### PR TITLE
Raise more meaningful error on unknown fully_qualified_name

### DIFF
--- a/lib/protocol_buffers/compiler/fully_qualified_name.rb
+++ b/lib/protocol_buffers/compiler/fully_qualified_name.rb
@@ -2,7 +2,10 @@ module ProtocolBuffers
   class FullyQualifiedName
     def self.to_class(fully_qualified_name)
       return nil if fully_qualified_name.nil?
-      service_typename(fully_qualified_name.to_s).split('::').inject(Object) { |mod, class_name| mod.const_get(class_name) if mod.const_defined?(class_name)}
+      service_typename(fully_qualified_name.to_s).split('::').inject(Object) { |mod, class_name|
+        raise CompileError, "Unknown fully qualified name #{fully_qualified_name}" if mod.nil?
+        mod.const_get(class_name) if mod.const_defined?(class_name)
+      }
     end
 
     def self.service_typename(type_name)

--- a/lib/protocol_buffers/version.rb
+++ b/lib/protocol_buffers/version.rb
@@ -1,3 +1,3 @@
 module ProtocolBuffers
-  VERSION = "1.5.1-nexia1"
+  VERSION = "1.5.1-nexia2"
 end

--- a/spec/compiler_spec.rb
+++ b/spec/compiler_spec.rb
@@ -73,4 +73,13 @@ describe ProtocolBuffers, "compiler" do
       File.join(File.dirname(__FILE__), "proto_files", "featureful.proto"))
   end
 
+  describe ProtocolBuffers::FullyQualifiedName do
+    describe ".to_class" do
+      it "raises a meaningful error on unknown fully qualified name" do
+        expect {
+          ProtocolBuffers::FullyQualifiedName.to_class("unknown.fully.qualified.name")
+        }.to raise_error(ProtocolBuffers::CompileError, "Unknown fully qualified name unknown.fully.qualified.name")
+      end
+    end
+  end
 end


### PR DESCRIPTION
This raises a meaningful error instead of NoMethodError: undefined method const_defined? on NilClass